### PR TITLE
Docs: fix invalid examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,7 +199,7 @@ en.toText(-123.12); // Negative one hundred twenty-three dollars and 12 cents</c
     .capitalize()
     .negativeSign()
     .build();
-en.toText(123.12); // Negative one hundred twenty-three dollars and 12 cents</code></pre>
+en.toText(-123.12); // Negative one hundred twenty-three dollars and 12 cents</code></pre>
                 </div>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -291,7 +291,7 @@ en.toText(25.17); // "twenty-five dollars seventeen cents"</code></pre>
     .capitalize()
     .build();
 
-String numberInText = en.toText(25.177); // "Twenty-five dollars point one seven seven"</code></pre>
+String numberInText = en.toText(25.177); // "Twenty-five point one seven seven"</code></pre>
                 </div>
 
                 <div id="solution2-2" class="code-block">
@@ -305,7 +305,7 @@ String numberInText = en.toText(25.177); // "Twenty-five dollars point one seven
         )
     )
 );
-numbify.toText(25.177); // "Twenty-five dollars point one seven seven"</code></pre>
+numbify.toText(25.177); // "Twenty-five point one seven seven"</code></pre>
                 </div>
             </div>
         </section>

--- a/index.html
+++ b/index.html
@@ -99,10 +99,10 @@ ru.toText(123.12); // сто двадцать три целых двенадца
 
                 <div id="solution7-2" class="code-block">
                     <button class="copy-btn">Copy</button>
-                    <pre><code class="language-java">Numbify en = new NumbifyBuilder()
+                    <pre><code class="language-java">Numbify ru = new NumbifyBuilder()
     .russian(Currency.NUMBER)
     .build();
-en.toText(123.12); // сто двадцать три целых двенадцать сотых</code></pre>
+ru.toText(123.12); // сто двадцать три целых двенадцать сотых</code></pre>
                 </div>
             </div>
 
@@ -128,11 +128,11 @@ ru.toText(123.12); // сто двадцать три целых 12 сотых</c
 
                 <div id="solution8-2" class="code-block">
                     <button class="copy-btn">Copy</button>
-                    <pre><code class="language-java">Numbify en = new NumbifyBuilder()
+                    <pre><code class="language-java">Numbify ru = new NumbifyBuilder()
     .russian(Currency.NUMBER)
     .originalDecimal()
     .build();
-en.toText(123.12); // сто двадцать три целых 12 сотых</code></pre>
+ru.toText(123.12); // сто двадцать три целых 12 сотых</code></pre>
                 </div>
             </div>
 
@@ -159,12 +159,12 @@ ru.toText(123.12); // Сто двадцать три целых 12 сотых</c
 
                 <div id="solution9-2" class="code-block">
                     <button class="copy-btn">Copy</button>
-                    <pre><code class="language-java">Numbify en = new NumbifyBuilder()
+                    <pre><code class="language-java">Numbify ru = new NumbifyBuilder()
     .russian(Currency.NUMBER)
     .originalDecimal()
     .capitalize()
     .build();
-en.toText(123.12); // Сто двадцать три целых 12 сотых</code></pre>
+ru.toText(123.12); // Сто двадцать три целых 12 сотых</code></pre>
                 </div>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@ ru.toText(123.12); // сто двадцать три целых двенадца
                     <pre><code class="language-java">Numbify en = new NumbifyBuilder()
     .russian(Currency.NUMBER)
     .build();
-en.toText(); // сто двадцать три целых двенадцать сотых</code></pre>
+en.toText(123.12); // сто двадцать три целых двенадцать сотых</code></pre>
                 </div>
             </div>
 
@@ -132,7 +132,7 @@ ru.toText(123.12); // сто двадцать три целых 12 сотых</c
     .russian(Currency.NUMBER)
     .originalDecimal()
     .build();
-en.toText(); // сто двадцать три целых 12 сотых</code></pre>
+en.toText(123.12); // сто двадцать три целых 12 сотых</code></pre>
                 </div>
             </div>
 
@@ -164,7 +164,7 @@ ru.toText(123.12); // Сто двадцать три целых 12 сотых</c
     .originalDecimal()
     .capitalize()
     .build();
-en.toText(); // Сто двадцать три целых 12 сотых</code></pre>
+en.toText(123.12); // Сто двадцать три целых 12 сотых</code></pre>
                 </div>
             </div>
 
@@ -199,7 +199,7 @@ en.toText(-123.12); // Negative one hundred twenty-three dollars and 12 cents</c
     .capitalize()
     .negativeSign()
     .build();
-en.toText(); // Negative one hundred twenty-three dollars and 12 cents</code></pre>
+en.toText(123.12); // Negative one hundred twenty-three dollars and 12 cents</code></pre>
                 </div>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -305,7 +305,7 @@ String numberInText = en.toText(25.177); // "Twenty-five dollars point one seven
         )
     )
 );
-en.toText(25.177); // "Twenty-five dollars point one seven seven"</code></pre>
+numbify.toText(25.177); // "Twenty-five dollars point one seven seven"</code></pre>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary

This PR fixes several incorrect examples in the project documentation.

## Changes

- Renamed variables representing Russian `Numbify` instances from `en` to `ru`.
- Added missing number arguments to `toText(...)` calls.
- Fixed the builder example for `negativeSign()` by passing a negative number.
- Fixed an object-composition example that called `toText(...)` on the wrong variable.
- Corrected expected outputs for examples using `Currency.NUMBER`:
  - removed the incorrect `dollars` currency text;
  - kept the configured `point` separator.