### PR TITLE
Add SurroundedText support

### DIFF
--- a/src/main/java/org/rus4j/numbify/NumbifyBuilder.java
+++ b/src/main/java/org/rus4j/numbify/NumbifyBuilder.java
@@ -16,6 +16,9 @@ public class NumbifyBuilder {
     private boolean originalDecimal = false;
     private boolean minusSign = false;
     private boolean digitByDigitDecimal = false;
+    private boolean surround = false;
+    private String prefix = "";
+    private String suffix = "";
     private TextEngine intTextEngine = new Text();
     private TextEngine decimalTextEngine = new Text();
 
@@ -106,6 +109,14 @@ public class NumbifyBuilder {
         return this;
     }
 
+    public NumbifyBuilder surround(String prefix, String suffix) {
+        surround = true;
+        this.prefix = prefix;
+        this.suffix = suffix;
+
+        return this;
+    }
+
     public Numbify build() {
         TextEngine textForDecimal = digitByDigitDecimal ? new DigitByDigitText() : decimalTextEngine;
         NumberText intText = originalInt ? new IntOriginalText() : new IntText(intTextEngine);
@@ -115,6 +126,7 @@ public class NumbifyBuilder {
         NumberText numberText = new CombinedText(intText, decimalText);
         numberText = minusSign ? new NegativeSignText(numberText) : numberText;
         numberText = capitalize ? new CapitalizedText(numberText) : numberText;
+        numberText = surround ? new SurroundedText(numberText, prefix, suffix) : numberText;
         return new Numbify(language, numberText);
     }
 }

--- a/src/main/java/org/rus4j/numbify/NumbifyBuilder.java
+++ b/src/main/java/org/rus4j/numbify/NumbifyBuilder.java
@@ -137,7 +137,6 @@ public class NumbifyBuilder {
         surround = true;
         this.prefix = prefix;
         this.suffix = suffix;
-
         return this;
     }
 

--- a/src/main/java/org/rus4j/numbify/SurroundedText.java
+++ b/src/main/java/org/rus4j/numbify/SurroundedText.java
@@ -17,7 +17,6 @@ public class SurroundedText implements NumberText {
     @Override
     public String toText(StringNumber number, Language language) {
         String text = numberText.toText(number, language);
-
         return text.isEmpty() ? "" : prefix + text + suffix;
     }
 }

--- a/src/main/java/org/rus4j/numbify/SurroundedText.java
+++ b/src/main/java/org/rus4j/numbify/SurroundedText.java
@@ -1,0 +1,23 @@
+package org.rus4j.numbify;
+
+import org.rus4j.numbify.lang.Language;
+import org.rus4j.numbify.number.StringNumber;
+
+public class SurroundedText implements NumberText {
+    private final NumberText numberText;
+    private final String prefix;
+    private final String suffix;
+
+    public SurroundedText(NumberText numberText, String prefix, String suffix) {
+        this.numberText = numberText;
+        this.prefix = prefix;
+        this.suffix = suffix;
+    }
+
+    @Override
+    public String toText(StringNumber number, Language language) {
+        String text = numberText.toText(number, language);
+
+        return text.isEmpty() ? "" : prefix + text + suffix;
+    }
+}

--- a/src/test/java/org/rus4j/numbify/SurroundedTextTest.java
+++ b/src/test/java/org/rus4j/numbify/SurroundedTextTest.java
@@ -1,0 +1,90 @@
+package org.rus4j.numbify;
+
+import org.junit.jupiter.api.Test;
+import org.rus4j.numbify.lang.Currency;
+import org.rus4j.numbify.lang.en.English;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SurroundedTextTest {
+    @Test
+    public void surroundedTextTest() {
+        Numbify en = new Numbify(
+                new English(Currency.NUMBER),
+                new SurroundedText(
+                        new IntText(new Text()),
+                        "(",
+                        ")"
+                )
+        );
+
+        assertThat(en.toText(123)).isEqualTo("(one hundred twenty-three)");
+    }
+
+    @Test
+    public void nestedSurroundedTextTest() {
+        Numbify en = new Numbify(
+                new English(Currency.NUMBER),
+                new SurroundedText(
+                        new CombinedText(
+                                new IntText(new Text()),
+                                new SurroundedText(
+                                        new DecimalText(new Text()),
+                                        "[",
+                                        "]"
+                                )
+                        ),
+                        "{",
+                        "}"
+                )
+        );
+
+        assertThat(en.toText(123.45)).isEqualTo("{one hundred twenty-three [forty-five]}");
+    }
+
+    @Test
+    public void surroundedCurrencyTextTest() {
+        Numbify en = new Numbify(
+                new English(Currency.USD),
+                new IntCurrencyText(
+                        new SurroundedText(
+                                new IntText(new Text()),
+                                "(",
+                                ")"
+                        )
+                )
+        );
+
+        assertThat(en.toText(123)).isEqualTo("(one hundred twenty-three) dollars");
+    }
+
+    @Test
+    public void surroundedNegativeTextTest() {
+        Numbify en = new Numbify(
+                new English(Currency.NUMBER),
+                new SurroundedText(
+                                new NegativeSignText(
+                                        new IntText(new Text())
+                                ),
+                                "(",
+                                ")"
+                )
+        );
+
+        assertThat(en.toText(-123)).isEqualTo("(negative one hundred twenty-three)");
+    }
+
+    @Test
+    public void surroundedEmptyTextTest() {
+        Numbify en = new Numbify(
+                new English(Currency.NUMBER),
+                new SurroundedText(
+                        new DecimalText(new Text()),
+                        "(",
+                        ")"
+                )
+        );
+
+        assertThat(en.toText(123)).isEmpty();
+    }
+}

--- a/src/test/java/org/rus4j/numbify/SurroundedTextTest.java
+++ b/src/test/java/org/rus4j/numbify/SurroundedTextTest.java
@@ -87,4 +87,16 @@ public class SurroundedTextTest {
 
         assertThat(en.toText(123)).isEmpty();
     }
+
+    @Test
+    public void surroundedTextWithABuilderTest() {
+        Numbify en = new NumbifyBuilder()
+                .english(Currency.NUMBER)
+                .hideIntCurrency()
+                .hideDecimalCurrency()
+                .surround("{", "}")
+                .build();
+
+        assertThat(en.toText(123.45)).isEqualTo("{one hundred twenty-three forty-five}");
+    }
 }


### PR DESCRIPTION
Closes #32

## Changes

- Added `SurroundedText` for wrapping any `NumberText` result with a configurable prefix and suffix.
- Added `surround(prefix, suffix)` to `NumbifyBuilder` for wrapping the complete resulting text.
- Added tests for `SurroundedText` and builder integration.

## Builder API question

I also considered adding more fine-grained builder methods:

- `surroundInt()`
- `surroundDecimal()`
- `surroundIntWithCurrency()`
- `surroundDecimalWithCurrency()`

This would allow distinguishing between cases like:

```text
(one hundred twenty-three) dollars
(one hundred twenty-three dollars)
((one hundred twenty-three dollars) (forty-five cents))
```

Would this be useful, or would it complicate the builder API?

I left these methods out for now.