### PR TITLE
Update AssertJ to 3.27.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ sourceCompatibility = JavaVersion.VERSION_17
 
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.7'
 }
 
 tasks.withType(Test).configureEach {


### PR DESCRIPTION
Hi, @rus4j. Recently, I was taking a closer look at the AssertJ documentation and came across [an XXE vulnerability](https://github.com/assertj/assertj/security/advisories/GHSA-rqfh-9r24-8c9r) affecting `assertj-core` versions up to `3.27.6`.

Numbify currently uses `assertj-core:3.27.3` as a test dependency. The affected XML assertion APIs are not used in the project, and AssertJ is only included via `testImplementation`, so the practical impact on Numbify appears to be very limited.

Still, since `3.27.7` contains the fix and I thought it would be worth sending this PR.
